### PR TITLE
Change list bypass method

### DIFF
--- a/scripting/voice_hud.sp
+++ b/scripting/voice_hud.sp
@@ -161,7 +161,7 @@ public void OnClientSpeakingEx(int client)
 		}
 		
 		//If user is an admin & exclude admins is true
-		if (!(GetUserAdmin(client) == INVALID_ADMIN_ID) && g_bExcludeAdmins)
+		if ((CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC)) && g_bExcludeAdmins)
 			return;
 			
 		g_alSpeaking.Push(client);

--- a/scripting/voice_hud.sp
+++ b/scripting/voice_hud.sp
@@ -161,7 +161,7 @@ public void OnClientSpeakingEx(int client)
 		}
 		
 		//If user is an admin & exclude admins is true
-		if ((CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC)) && g_bExcludeAdmins)
+		if ((CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC)) && !IsFakeClient && g_bExcludeAdmins)
 			return;
 			
 		g_alSpeaking.Push(client);

--- a/scripting/voice_hud.sp
+++ b/scripting/voice_hud.sp
@@ -161,7 +161,7 @@ public void OnClientSpeakingEx(int client)
 		}
 		
 		//If user is an admin & exclude admins is true
-		if ((CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC)) && !IsFakeClient && g_bExcludeAdmins)
+		if ((CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC)) && !IsFakeClient(client) && g_bExcludeAdmins)
 			return;
 			
 		g_alSpeaking.Push(client);

--- a/scripting/voice_hud.sp
+++ b/scripting/voice_hud.sp
@@ -160,8 +160,12 @@ public void OnClientSpeakingEx(int client)
 			return;
 		}
 		
+		//Ignore Bots
+		if (IsFakeClient(client))
+			return;
+		
 		//If user is an admin & exclude admins is true
-		if ((CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC)) && !IsFakeClient(client) && g_bExcludeAdmins)
+		if (CheckCommandAccess(client, "voicehud_bypass", ADMFLAG_GENERIC) && g_bExcludeAdmins)
 			return;
 			
 		g_alSpeaking.Push(client);


### PR DESCRIPTION
One of my moderators approached me and asked why our donors (reservation and custom flags) were bypassing the voice hud list, so I went ahead and looked into it, which lead me to this PR.

This PR changes the method of how "Admins" bypass being on the voice hud list. [As documented](https://wiki.alliedmods.net/Checking_Admin_Flags_(SourceMod_Scripting)#The_last_fallback:_GetAdminFlag_.2F_GetUserFlagBits), CheckCommandAccess should always be the preferred method of checking admin status (unless there was a reason you are using GetUserAdmin). Not only does this fix the issue of non-"admins" being improperly excluded from the list, this also provides an override, if server owners would want to override the list bypass for any other flags.

Entirely untested, but in theory should work just fine.